### PR TITLE
Update working operating systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Platform Requirements
 At the time of writing the portable version is known to build and work on:
 
  - OpenBSD
- - Alpine 3.12
+ - Alpine 3.13
  - Debian 9, 10
- - Fedora 31, 32, 33
- - RHEL/CentOS 7, 8
+ - Fedora 32, 33, 34
+ - CentOS/RHEL/Rocky 7, 8
  - Ubuntu 20.04 LTS
  - FreeBSD 12
 


### PR DESCRIPTION
  * Alpine 3.13 has been released a while ago (and OpenBGPD works there)
  * Fedora 31 is EOL, Fedora 34 has been released recently (and OpenBGPD works there)
  * CentOS becomes upstream of RHEL and Rocky got a downstream of RHEL (and OpenBGPD works on all of them)
