### PR TITLE
Update working Linux distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Platform Requirements
 At the time of writing the portable version is known to build and work on:
 
  - OpenBSD
- - Alpine 3.13
+ - Alpine 3.15
  - Debian 9, 10
- - Fedora 32, 33, 34
- - CentOS/RHEL/Rocky 7, 8
+ - Fedora 34, 35, 36, 37
+ - CentOS/RHEL/Rocky 7, 8, 9
  - Ubuntu 20.04 LTS
  - FreeBSD 12
 


### PR DESCRIPTION
  * My Docker/Quay containers are already built using Alpine 3.15
  * RHEL 9 is around the corner (and EPEL 9 builds are working fine)
  * Fedora 32 and 33 are EOL, 36 is around the corner, 37 is next