### PR TITLE
Add portability shim for WAIT_ANY for musl libc

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -9,6 +9,7 @@ noinst_HEADERS += sys/socket.h
 noinst_HEADERS += sys/time.h
 noinst_HEADERS += sys/tree.h
 noinst_HEADERS += sys/types.h
+noinst_HEADERS += sys/wait.h
 noinst_HEADERS += endian.h
 noinst_HEADERS += imsg.h
 noinst_HEADERS += sha2.h

--- a/include/sys/wait.h
+++ b/include/sys/wait.h
@@ -1,0 +1,15 @@
+/*
+ * Public domain
+ * sys/wait.h compatibility shim
+ */
+
+#include_next <sys/wait.h>
+
+#ifndef LIBCOMPAT_SYS_WAIT_H
+#define LIBCOMPAT_SYS_WAIT_H
+
+#ifndef WAIT_ANY
+#define WAIT_ANY (-1)
+#endif
+
+#endif


### PR DESCRIPTION
Actually the same like the following changes at rpki-client:

 - https://github.com/rpki-client/rpki-client-portable/blob/master/include/sys/wait.h
 - https://github.com/rpki-client/rpki-client-portable/commit/1a7e6dfd9720d283d4ed6288144dd7b45bbef74b