### PR TITLE
Add CodeQL analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,0 +1,39 @@
+name: CodeQL analysis
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # build the main branch every Monday morning
+    - cron: '22 5 * * 1'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp' ]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+    - name: Build Application using script
+      run: |
+        ./autogen.sh
+        sudo apt-get install libevent-dev
+        ./configure
+        make
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
LGTM.com will be shut down in December 2022 and recommend to use GitHub code scanning instead.

See also: https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/