### PR TITLE
Switch to gcc-12 (default: gcc-11), clang-14 is newest in ubuntu-latest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [cc, clang, clang-12, gcc-10]
+        compiler: [cc, clang, gcc-12]
     steps:
       - uses: actions/checkout@v3
       - name: install missing deps


### PR DESCRIPTION
See also: https://github.com/rpki-client/rpki-client-portable/commit/bffd99f1f743ad5e70fab91e78a71fca00a76af3