### PR TITLE
Bump GitHub actions/checkout from 3 to 4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         compiler: [cc, clang, gcc-12]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: install missing deps
         run: sudo apt-get install libevent-dev
       - name: autogen

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -22,7 +22,7 @@ jobs:
         language: [ 'cpp' ]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:


### PR DESCRIPTION
Main change is an update of the default runtime to Node 20 inside the action.

Note: `actions/checkout@v4,` needs to be added to https://github.com/openbgpd-portable/openbgpd-portable/settings/actions to make this pull request passing.