### PR TITLE
Add link to SUSE systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ At the time of writing the portable version is known to build and work on:
  - CentOS/RHEL/Rocky 7, 8, 9
  - Ubuntu 20.04 LTS
  - FreeBSD 12, 13
+ - openSUSE
+ - SLE 15
 
 OpenBGPD may work on other operating systems, newer and older, but the above
 ones are tested regularly by the developer.


### PR DESCRIPTION
Yes, openSUSE (and SUSE Linux Enterprise) supports OpenBGPD ;-)

https://build.opensuse.org/package/show/network/openbgpd