### PR TITLE
freebsd: fix crash on interface destroy

### DIFF
--- a/src/bgpd/kroute-freebsd.c
+++ b/src/bgpd/kroute-freebsd.c
@@ -1492,6 +1492,9 @@ kroute_matchgw(struct kroute *kr, struct kroute_full *kf)
 	in_addr_t	nexthop;
 
 	if (kf->flags & F_CONNECTED) {
+		/* if interface is destroyed, it's loopback */
+		if (!kf->ifindex)
+			return (kr);
 		do {
 			if (kr->ifindex == kf->ifindex)
 				return (kr);
@@ -1839,6 +1842,9 @@ kroute6_matchgw(struct kroute6 *kr, struct kroute_full *kf)
 	struct in6_addr	nexthop;
 
 	if (kf->flags & F_CONNECTED) {
+		/* if interface is destroyed, it's loopback */
+		if (!kf->ifindex)
+			return (kr);
 		do {
 			if (kr->ifindex == kf->ifindex)
 				return (kr);


### PR DESCRIPTION
## Problem

If you destroy an interface on FreeBSD platform, the rtm->index will set to 0 for RTF_HOST prefixes. Therefore, openbgpd can't find relevant kr for F_CONNECTED kf.

`src/bgpd/kroute-freebsd.c`:

```c
struct kroute6 *
kroute6_matchgw(struct kroute6 *kr, struct kroute_full *kf)
{
	struct in6_addr	nexthop;

	if (kf->flags & F_CONNECTED) {
		do {
			if (kr->ifindex == kf->ifindex)
				return (kr);
			kr = kr->next;
		} while (kr);
		return (NULL);
	}
```

### Reproduce Crash:

- OS: FreeBSD 14-STABLE, FreeBSD-Current

```sh
ifconfig tun create inet6 2a01:e140:dead:cafe::1/64
bgpd -dv
ifconfig tun0 destroy
```

#### Output:

bgpd output:

```sh
if_change: tun0: rdomain 0 DOWN, unknown media, unknown, 0 bps
delete 2a01:e140:dead:cafe::1/128: route not found
peer closed imsg connection
SE: Lost connection to parent
kernel routing table 0 (Loc-RIB) decoupled
ktable_destroy: freeing ktable Loc-RIB rtableid 0
peer closed imsg connection
peer closed imsg connection
neighbor fdb5:c59b:114e:8db4::5 (obgp2): session stop: Cease, administratively down
fatal in RDE: Lost connection to parent
fatal in RTR: Lost connection to parent
waiting for children to terminate
neighbor fdb5:c59b:114e:8db4::5 (obgp2): state change Connect -> Idle, reason: Stop
session engine exiting
terminating
```

gdb:

```c
(gdb) p *kr
$2 = {entry = {rbe_left = 0x17000b1236, rbe_right = 0x0, rbe_parent = 0x0, rbe_color = 0}, next = 0x0, prefix = {s_addr = 0}, nexthop = {s_addr = 0}, mplslabel = 0, flags = 0, labelid = 0, ifindex = 0, 
  prefixlen = 0 '\000', priority = 0 '\000'}
```
 
## Solution

Return the exact F_CONNECTED kr, if kf->ifindex was set to 0.