### PR TITLE
Add include of arpa/inet.h

### DIFF
--- a/src/bgpd/kroute-linux.c
+++ b/src/bgpd/kroute-linux.c
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 #include <sys/tree.h>
 #include <sys/socket.h>
+#include <arpa/inet.h>
 #include <limits.h>
 #include <ifaddrs.h>
 #include <stdlib.h>


### PR DESCRIPTION
Fixes #99:
```
kroute-linux.c: In function 'kroute4_remove':
kroute-linux.c:1760:47: error: implicit declaration of function 'inet_ntoa' [-Wimplicit-function-declaration]
 1760 |                                     __func__, inet_ntoa(kr->prefix),
```