### PR TITLE
Switch gcc-12 to gcc-14, default is gcc-13

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [cc, clang, gcc-12]
+        compiler: [cc, clang, gcc-14]
     steps:
       - uses: actions/checkout@v4
       - name: install missing deps


### PR DESCRIPTION
It makes more sense to test building using a more than less recent compiler. Unfortunately, Ubuntu 24.04 LTS doesn't provide GCC 15 (yet?).