### PR TITLE
Fix IPTOS_DSCP_VA fallback

### DIFF
--- a/include/netinet/ip.h
+++ b/include/netinet/ip.h
@@ -17,9 +17,6 @@
 #ifndef IPTOS_DSCP_AF11
 #define	IPTOS_DSCP_AF11		0x28
 #endif
-#ifndef IPTOS_DSCP_VA
-#define IPTOS_DSCP_VA		0x2c
-#endif
 #ifndef IPTOS_DSCP_AF12
 #define	IPTOS_DSCP_AF12		0x30
 #endif
@@ -64,6 +61,9 @@
 #endif
 #ifndef IPTOS_DSCP_CS5
 #define	IPTOS_DSCP_CS5		0xa0
+#endif
+#ifndef IPTOS_DSCP_VA
+#define IPTOS_DSCP_VA		0xb0
 #endif
 #ifndef IPTOS_DSCP_EF
 #define	IPTOS_DSCP_EF		0xb8


### PR DESCRIPTION
0x2c is the unshifted value, and was copied over from openbsd before it was fixed to be 0xb0 in [0].

Source of discrepancy identified by Leah Neukirchen.

[0] https://cvsweb.openbsd.org/log/src/sys/netinet/ip.h#rev1.22