### PR TITLE
sync zizmor fixes from rpki-client

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         compiler: [cc, clang, gcc-14]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: install missing deps

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,8 @@ jobs:
         compiler: [cc, clang, gcc-14]
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: install missing deps
         run: |
           sudo apt-get update

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -22,7 +22,7 @@ jobs:
         language: [ 'cpp' ]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -26,7 +26,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba #v4.35.5
       with:
         languages: ${{ matrix.language }}
     - name: Build Application using script
@@ -37,6 +37,6 @@ jobs:
         ./configure
         make
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba #v4.35.5
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       with:

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -18,7 +18,7 @@ jobs:
       contents: read
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/coverity.yaml
+++ b/.github/workflows/coverity.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: "Install dependencies"
         run: |


### PR DESCRIPTION
This leaves out the coverity workflow since the service went belly-up again, so I can't move the secret.